### PR TITLE
`options.type` can only be error, success, or nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Concurrent notifications are stacked, most recent at the top.
 	nNotification.show({
 		title: 'Optional title',
 		content:'<p>Here is a message</p>',
-		type:'myft', // optional see below
+		type: 'success', // optional see below
 		duration: 7000 // optional, default is 5000
 	});
 
@@ -24,14 +24,14 @@ Concurrent notifications are stacked, most recent at the top.
 
 ## Types
 
-	type is optional
+`type` is optional, but if specified must have one of the following values:
 
-	'error', produces an error styled notification (red).
-	'success', styled green
+* `error`, produces an error styled notification (red).
+* `success`, styled green
 
 	any other type or if type is not provided, will result in a default FT pink notification.
 
 # Ideas for the future
 
-* Using the Notifications and PageVisibility APIS to show people notifications with the FT open in the background.
+* Using the Notifications and PageVisibility APIs to show people notifications with the FT open in the background.
 * Firing messages and notifcations from Server Sent Events

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 const template = require('./src/js/template');
 const timeoutDuration = 5000;
+const supportedTypes = ['error', 'success'];
 
 const stack = [];
 const eventShow = (e) => show(e.detail);
@@ -11,6 +12,10 @@ class Notice {
 	constructor (options) {
 
 		options.trackable = options.trackable || `notification-${options.type}`;
+
+		if (options.type && supportedTypes.includes(options.type)) {
+			options.modifier = options.type;
+		}
 
 		this.notice = document.createElement('div');
 		this.notice.appendChild(template(options));

--- a/src/js/template.js
+++ b/src/js/template.js
@@ -1,7 +1,13 @@
 module.exports = (options) => {
 
 	const noticeEl = document.createElement('div');
-	noticeEl.className = `n-notification__item n-notification--${options.type ? options.type : 'default'}`;
+
+	noticeEl.classList.add('n-notification__item');
+
+	if (options.modifier) {
+		noticeEl.classList.add(`n-notification--${options.modifier}`);
+	}
+
 	noticeEl.setAttribute("role", "alert");
 	noticeEl.setAttribute("data-trackable", options.trackable);
 

--- a/tests/notification.spec.js
+++ b/tests/notification.spec.js
@@ -38,6 +38,12 @@ describe('Notifications', () => {
 			expect(document.querySelector('.n-notification--success')).not.to.be.null;
 		});
 
+		it('should not set modifier class for unsupported types', () => {
+			nNotification.show({type: 'indifferent'});
+			expect(document.querySelector('.n-notification--indifferent')).to.be.null;
+			expect(document.querySelector('.n-notification--default')).to.be.null;
+		});
+
 		it('should remove the message after the specified timeout', () => {
 			nNotification.show({title: 'Title', content: 'Content', duration: defaultDuration});
 			expect(document.querySelector('.n-notification__item')).not.to.be.null;


### PR DESCRIPTION
Setting `options.type` to anything other than `error` or `success` will do nothing - no modifier class will be set.

The only usage of **n-notification** where type is anything other than `error` or `success` is here, where it is set to `default`: https://github.com/Financial-Times/n-myft-ui/blob/01f3460338a7a63d1d3ff7b6829e4fc34c7f6e7d/myft/ui/lists.js#L40

Nothing seems to depend on the `--default` modifier class though, so I'll raise a PR to remove that.

Fixes #49 