### PR TITLE
Add an option to set focus on a notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
 # n-notification [![Circle CI](https://circleci.com/gh/Financial-Times/n-notification/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/n-notification/tree/master)
-Component for showing onsite notification bars to users.
-Concurrent notifications are stacked, most recent at the top.
+Component for showing onsite notification bars to users. Concurrent notifications are stacked, most recent at the top.
 
-# Using it
+# Usage
 
 ## Programatically
 
-	const nNotification = require('n-notification');
+```js
+const nNotification = require('n-notification');
 
-	nNotification.show({
-		title: 'Optional title',
-		content:'<p>Here is a message</p>',
-		type: 'success', // optional see below
-		duration: 7000 // optional, default is 5000
-	});
+nNotification.show({
+	title: 'Optional title',
+	content:'<p>Here is a message</p>',
+	type: 'success', // optional, see below
+	duration: 7000, // default is 5000
+	focusSelector: '.optional-focus-selector',
+	returnFocusSelector: document.activeElement
+});
+```
 
 ## Custom Events
 
-	require('n-notification').init();
+```js
+require('n-notification').init();
 
-	const event = new CustomEvent('nNotification.show', {detail: { content: 'Title' }});
-	document.dispatchEvent(event);
+const event = new CustomEvent('nNotification.show', {detail: { content: 'Title' }});
+document.dispatchEvent(event);
+```
 
 ## Types
 
@@ -29,9 +34,13 @@ Concurrent notifications are stacked, most recent at the top.
 * `error`, produces an error styled notification (red).
 * `success`, styled green
 
-	any other type or if type is not provided, will result in a default FT pink notification.
+If a type is not provided, it will result in a default FT pink notification.
+
+## Focus Selectors
+
+If you want to set the focus to a notification element, pass in the `focusSelector` and `returnFocusSelector` properties with an element (e.g. `.optional-focus-selector`) or a document property (e.g. `document.activeElement`). The `focusSelector` property is the notification element you want to focus on. The `returnFocusSelector` property is the element you want to return the focus to once the notification has cleared.
 
 # Ideas for the future
 
 * Using the Notifications and PageVisibility APIs to show people notifications with the FT open in the background.
-* Firing messages and notifcations from Server Sent Events
+* Firing messages and notifications from Server Sent Events

--- a/main.js
+++ b/main.js
@@ -17,6 +17,9 @@ class Notice {
 			options.modifier = options.type;
 		}
 
+		options.returnFocusSelector = options.returnFocusSelector instanceof Element ? options.returnFocusSelector : document.querySelector(options.returnFocusSelector);
+		this.options = options;
+
 		this.notice = document.createElement('div');
 		this.notice.appendChild(template(options));
 		this.notice.querySelector('button').onclick = this.hide.bind(this);
@@ -39,6 +42,10 @@ class Notice {
 			stack.splice(index, 1);
 		}
 		this.dispatchNotificationCloseEvent();
+
+		if (this.options.returnFocusSelector) {
+			this.options.returnFocusSelector.focus();
+		}
 	}
 
 	dispatchNotificationCloseEvent () {
@@ -54,6 +61,13 @@ function show (options) {
 		lastNotice.timeout = setTimeout(lastNotice.hide.bind(lastNotice), timeoutDuration);
 	} else {
 		stack.push(new Notice(options));
+	}
+
+	if (options.focusSelector) {
+		const focusEl = options.focusSelector instanceof Element ? options.focusSelector : document.querySelector(options.focusSelector);
+		if (focusEl) {
+			focusEl.focus();
+		}
 	}
 }
 

--- a/src/js/template.js
+++ b/src/js/template.js
@@ -22,7 +22,7 @@ module.exports = (options) => {
 	}
 
 	if (options.content) {
-		const contentEl = document.createElement('div');
+		const contentEl = document.createElement('span');
 		contentEl.className = "n-notification__content";
 		contentEl.innerHTML = options.content;
 		contentWrapperEl.appendChild(contentEl);

--- a/src/js/template.js
+++ b/src/js/template.js
@@ -8,7 +8,6 @@ module.exports = (options) => {
 		noticeEl.classList.add(`n-notification--${options.modifier}`);
 	}
 
-	noticeEl.setAttribute("role", "alert");
 	noticeEl.setAttribute("data-trackable", options.trackable);
 
 	const contentWrapperEl = document.createElement('div');
@@ -25,6 +24,7 @@ module.exports = (options) => {
 		const contentEl = document.createElement('span');
 		contentEl.className = "n-notification__content";
 		contentEl.innerHTML = options.content;
+		contentEl.setAttribute("role", "alert");
 		contentWrapperEl.appendChild(contentEl);
 	}
 


### PR DESCRIPTION
When a notification appears on the page, the focus doesn't shift to it,
instead it remains on the present element. This makes it difficult for
keyboard users to navigate to the notification.

This PR adds two optional properties, `focusSelector` and
`returnFocusSelector`. They allow you to set the notification element to
focus on and the element you want to return the focus on once the
notification clears.