### PR TITLE
Update demo with example fo explicit dismissal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ nNotification.show({
 	title: 'Optional title',
 	content:'<p>Here is a message</p>',
 	type: 'success', // optional, see below
-	duration: 7000, // default is 5000
+	duration: 7000, // default is 5000, 0 will require user action to dismiss
 	focusSelector: '.optional-focus-selector',
 	returnFocusSelector: document.activeElement
 });
@@ -39,6 +39,12 @@ If a type is not provided, it will result in a default FT pink notification.
 ## Focus Selectors
 
 If you want to set the focus to a notification element, pass in the `focusSelector` and `returnFocusSelector` properties with an element (e.g. `.optional-focus-selector`) or a document property (e.g. `document.activeElement`). The `focusSelector` property is the notification element you want to focus on. The `returnFocusSelector` property is the element you want to return the focus to once the notification has cleared.
+
+## Duration and accessibility
+timeOut default is 5000ms.
+
+0 will require the users to explicitly dismiss the message. This is the recommended UX from [DAC](https://digitalaccessibilitycentre.org/) It was highlighted this could be too quick for dyslexic or some cognitively different users in Aug 2019 DAC assesment.
+
 
 # Ideas for the future
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If a type is not provided, it will result in a default FT pink notification.
 If you want to set the focus to a notification element, pass in the `focusSelector` and `returnFocusSelector` properties with an element (e.g. `.optional-focus-selector`) or a document property (e.g. `document.activeElement`). The `focusSelector` property is the notification element you want to focus on. The `returnFocusSelector` property is the element you want to return the focus to once the notification has cleared.
 
 ## Duration and accessibility
-timeOut default is 5000ms.
+The timeout default is 5000ms.
 
 0 will require the users to explicitly dismiss the message. This is the recommended UX from [DAC](https://digitalaccessibilitycentre.org/) It was highlighted this could be too quick for dyslexic or some cognitively different users in Aug 2019 DAC assesment.
 

--- a/demos/all.html
+++ b/demos/all.html
@@ -14,6 +14,7 @@
 <button class="demo-notification--method">Notification from Method</button>
 <button class="demo-notification--error">Notification with error style</button>
 <button class="demo-notification--success">Notification with success style</button>
+<button class="demo-notification--keep">Notification requries explicit dismissal</button>
 
 <script src="/bundles/js?modules=n-notification:/demos/src/main.js"></script>
 <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>

--- a/demos/src/all.html
+++ b/demos/src/all.html
@@ -1,3 +1,4 @@
 <button class="demo-notification--method">Notification from Method</button>
 <button class="demo-notification--error">Notification with error style</button>
 <button class="demo-notification--success">Notification with success style</button>
+<button class="demo-notification--keep">Notification requries explicit dismissal</button>

--- a/demos/src/main.js
+++ b/demos/src/main.js
@@ -3,6 +3,7 @@ const demoEvent = document.querySelector('.demo-notification--event');
 const demoMethod = document.querySelector('.demo-notification--method');
 const demoError = document.querySelector('.demo-notification--error');
 const demoSuccess = document.querySelector('.demo-notification--success');
+const demoKeep = document.querySelector('.demo-notification--keep');
 
 if (demoEvent) {
 	demoEvent.addEventListener('click', function() {
@@ -21,7 +22,7 @@ if (demoMethod) {
 	demoMethod.addEventListener('click', function() {
 		nNotification.show({
 			title: 'Title',
-			content: 'Notification generated via nNotification.show method'
+			content: 'Notification generated via nNotification.show method duration set at 5s (timeout default)'
 		});
 	});
 }
@@ -30,8 +31,9 @@ if (demoError) {
 	demoError.addEventListener('click', function() {
 		nNotification.show({
 			title: 'Error',
-			content: 'This Notification is styled as an error',
-			type: 'error'
+			content: 'This Notification is styled as an error, duration set at 4s',
+			type: 'error',
+			duration: 4000
 		});
 	});
 }
@@ -40,8 +42,19 @@ if (demoSuccess) {
 	demoSuccess.addEventListener('click', function() {
 		nNotification.show({
 			title: 'Success',
-			content: 'This Notification is styled as a success',
-			type: 'success'
+			content: 'This Notification is styled as a success, duration set at 3s',
+			type: 'success',
+			duration: 3000
+		});
+	});
+}
+
+if (demoKeep) {
+	demoKeep.addEventListener('click', function() {
+		nNotification.show({
+			title: 'Explicit dismissal',
+			content: 'Notification generated via nNotification.show keep, duration 0 requires explicit dismissal',
+			duration: 0
 		});
 	});
 }


### PR DESCRIPTION
 🐿 v2.12.4

DAC assesement has suggested our default timeout is too quick on n-notification although no explicit value has been suggested. Instead the recommendation is to let users explicitly dismiss notificatiations. Comments from the [DAC](https://digitalaccessibilitycentre.org/) report:

'Ensure the banner is displayed for a significant amount of time in relation to the content.
Alternatively, and preferably, keep the details on the page until dismissed.
This would be more appropriate as a popup dialog.'
