### PR TITLE
transfer ownership to @Financial-Times/content-discovery

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* @Financial-Times/acquisition
+* @Financial-Times/content-discovery


### PR DESCRIPTION
While raising this: https://github.com/Financial-Times/n-notification/pull/73

We noticed that n-notification is not used by the acquisition team.

However it is used in:
- https://github.com/Financial-Times/n-myft-ui/blob/master/myft/ui/myft-buttons/init.js#L6
- https://github.com/Financial-Times/next-stream-page/blob/master/client/components/expandable-card/main.js#L2

Both are owned by content-discovery so I've raised this with @umbobabo who has agreed to transfer the repo.