### PR TITLE
update readme to point at origami monorepo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,7 @@ jobs:
     docker:
       - image: 'circleci/node:10-browsers'
     steps:
-      - checkout
-      - run: npm install --only=dev
-      - run: npx origami-ci branch
-  publish_to_npm:
-    docker:
-      - image: 'circleci/node:10'
-    steps:
-      - checkout
-      - run: npm install --only=dev
-      - run: npx origami-ci release
+      - run: echo ':)'
 workflows:
   version: 2
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# n-notification [![Circle CI](https://circleci.com/gh/Financial-Times/n-notification/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/n-notification/tree/master)
+# n-notification 
+
+🚨 This component is now managed in the [origami component system](https://github.com/Financial-Times/origami/components/n-notification) 🚨
+
 Component for showing onsite notification bars to users. Concurrent notifications are stacked, most recent at the top.
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # n-notification 
 
-🚨 This component is now managed in the [origami component system](https://github.com/Financial-Times/origami/components/n-notification) 🚨
+🚨 This component is now managed in the [origami component system](https://github.com/Financial-Times/origami/tree/main/components/n-notification) 🚨
 
 Component for showing onsite notification bars to users. Concurrent notifications are stacked, most recent at the top.
 


### PR DESCRIPTION
This component is now managed within the origami monorepo, so let's add a helpful note for folks and then archive the n-notification repo :)


https://github.com/Financial-Times/origami/tree/main/components/n-notification